### PR TITLE
update schema to use Decimal instead of money type

### DIFF
--- a/Database/schema.sql
+++ b/Database/schema.sql
@@ -1,5 +1,6 @@
 DROP TABLE IF EXISTS price_readings, subscriptions, users, products;
 
+
 CREATE TABLE products(
     product_id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     url TEXT UNIQUE NOT NULL,
@@ -16,12 +17,12 @@ CREATE TABLE subscriptions (
     subscription_id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     user_id INTEGER NOT NULL REFERENCES users (user_id),
     product_id INTEGER NOT NULL REFERENCES products (product_id),
-    price_threshold MONEY
+    price_threshold DECIMAL(12, 2)
 );
 
 CREATE TABLE price_readings (
     reading_id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     product_id INTEGER NOT NULL REFERENCES products (product_id),
     reading_at TIMESTAMP(0) NOT NULL,
-    price MONEY NOT NULL
+    price DECIMAL(12, 2) NOT NULL
 );


### PR DESCRIPTION
Changes the schema to use `DECIMAL` type instead of `MONEY`. `MONEY` is non-standard and it seems to be a historical left-over.